### PR TITLE
Doc building suffix bug

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -46,7 +46,6 @@ templates_path = ['_templates']
 # The suffix(es) of source filenames.
 # You can specify multiple suffix as a list of string:
 # source_suffix = ['.rst', '.md']
-source_suffix = '.md'
 
 # The encoding of source files.
 #source_encoding = 'utf-8-sig'

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,2 @@
+[bdist_wheel]
+universal = 1


### PR DESCRIPTION
The default file extension was incorrectly overwritten for some reason.